### PR TITLE
Bare bone version of the bigtable emulator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.9-alpine3.6 as builder
+
+MAINTAINER Julien Letrouit "julien.letrouit@shopify.com"
+
+RUN apk update && apk upgrade && apk add git && \
+    go get -u cloud.google.com/go/bigtable
+
+ADD bigtable-emulator.go /go/bin/bigtable-emulator.go
+
+RUN go build /go/bin/bigtable-emulator.go
+
+
+FROM alpine:3.6
+
+COPY --from=builder /go/bigtable-emulator /
+
+ENTRYPOINT ["/bigtable-emulator"]
+
+EXPOSE 9035

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Bigtable emulator Docker image
+
+This repository contains the Google Cloud Bigtable emulator, which is an in memory Go impliementation of Bigtable allowing to create integration tests and local development. Warning: this is not a production tool.
+
+The emulator is offered in the [Google Cloud SDK](https://cloud.google.com/bigtable/docs/emulator). However, this might be difficult or overkill to install the SDK locally on every development and CI box. In that case, this image provides a lightweight alternative (the image is around 17MB). It also provides an easy way to setup necessary tables and column families at startup.
+
+To start it, run the following command:
+
+```
+docker run -it -p 9035:9035 shopify/bigtable-emulator
+```
+
+You can specify the tables and column families you need using the `-cf` switch. The format is a comma separated list of <instance>.<table>.<column family>. Ex:
+
+```
+docker run -it -p 9035:9035 shopify/bigtable-emulator -cf dev.records.data,dev.records.metadata
+```
+
+## Using it
+
+You have to set the `BIGTABLE_EMULATOR_HOST` to the right docker host and container port. For example: `localhost:9035`. And then:
+
+```go
+import (
+  "cloud.google.com/go/bigtable"
+  "golang.org/x/net/context"
+)
+
+func NewDevBigTableClient() (*bigtable.Client, error) {
+  ctx := context.Background()
+  project := "dev"
+  instance := "dev"
+  return bigtable.NewClient(
+    ctx, 
+    project, 
+    instance
+  )
+}
+
+```
+
+## License
+
+This software is available under the MIT license (see 'LICENSE' file for more details).

--- a/bigtable-emulator.go
+++ b/bigtable-emulator.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+        "context"
+        "fmt"
+        "os"
+        "os/signal"
+        "syscall"
+        "cloud.google.com/go/bigtable/bttest"
+        "cloud.google.com/go/bigtable"
+        "google.golang.org/grpc"
+        "strings"
+        "google.golang.org/api/option"
+        "flag"
+        "errors"
+)
+
+func main() {
+        cfs := flag.String("cf", "", "Optional: the column families to create at startup. Format: a series of <instance>.<table>.<column familiy>, comma separated. Ex: \n          docker run -d spotify/bigtable-emulator -cf dev.records.data,dev.records.metadata")
+        flag.Parse()
+
+        srv, err := bttest.NewServer("0.0.0.0:9035")
+        if err != nil {
+                fmt.Fprintf(os.Stderr, "error starting the server: %v\n", err)
+                return
+        }
+        defer srv.Close()
+
+        if err = createColumnFamiliies(*cfs); err != nil {
+                fmt.Fprintf(os.Stderr, "error creating the column familiies: %v\n", err)
+                return
+        }
+
+        sigs := make(chan os.Signal, 1)
+        signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+        fmt.Printf("Bigtable emulator running on %s\n", srv.Addr)
+        <-sigs
+        fmt.Println("done")
+}
+
+func createColumnFamiliies(specifications string) error {
+        if specifications == "" {
+                return nil
+        }
+
+        ctx := context.Background()
+        conn, err := grpc.Dial("localhost:9035", grpc.WithInsecure())
+        if err != nil {
+                return fmt.Errorf("could not connect to bigtable emulator: %v", err)
+        }
+
+        for _, specification := range strings.Split(specifications, ",") {
+                specificationElements := strings.Split(specification, ".")
+                if len(specificationElements) != 3 {
+                        return errors.New("format of column family to create is <instance>.<table>.<column family>")
+                }
+
+                instance := specificationElements[0]
+                table := specificationElements[1]
+                columnFamily := specificationElements[2]
+
+                client, err := bigtable.NewAdminClient(ctx, "dev", instance, option.WithGRPCConn(conn))
+                if err != nil {
+                        return fmt.Errorf("failed to create admin client: %v", err)
+                }
+
+                tables, err := client.Tables(ctx)
+                if !tableExists(tables, table) {
+                        if err = client.CreateTable(ctx, table); err != nil {
+                                return err
+                        }
+                }
+
+                tableInfo, err := client.TableInfo(ctx, table)
+                if !columnFamilyExists(tableInfo.FamilyInfos, columnFamily) {
+                        fmt.Printf("creating %v.%v.%v column family\n", instance, table, columnFamily)
+                        if err := client.CreateColumnFamily(ctx, table, columnFamily); err != nil {
+                                return err
+                        }
+                }
+        }
+
+        return nil
+}
+
+func tableExists(tables []string, table string) bool {
+        for _, item := range tables {
+                if item == table {
+                        return true
+                }
+        }
+        return false
+}
+
+func columnFamilyExists(columnFamilies []bigtable.FamilyInfo, columnFamily string) bool {
+        for _, family := range columnFamilies {
+                if family.Name == columnFamily {
+                        return true
+                }
+        }
+        return false
+}


### PR DESCRIPTION
- small image footprint (< 17MB)
- support for creating tables and column families at startup
- properly suited for open source access